### PR TITLE
feat(daemon): add application time tracking during focus sessions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1596,6 +1596,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "which",
+ "x11rb",
 ]
 
 [[package]]

--- a/crates/flux-adapters/src/lib.rs
+++ b/crates/flux-adapters/src/lib.rs
@@ -8,5 +8,5 @@ pub mod sqlite;
 pub mod testing;
 
 pub use gitlab::GitLabReviewGateway;
-pub use sqlite::SqliteSessionRepository;
+pub use sqlite::{SqliteAppTrackingRepository, SqliteSessionRepository};
 pub use testing::{FailingReviewGateway, StubReviewGateway};

--- a/crates/flux-adapters/src/sqlite/app_tracking_repository.rs
+++ b/crates/flux-adapters/src/sqlite/app_tracking_repository.rs
@@ -1,0 +1,316 @@
+use std::path::Path;
+use std::sync::Mutex;
+
+use rusqlite::{params, Connection};
+
+use flux_core::{AppTrackingRepository, AppTrackingRepositoryError, AppUsage, SessionId};
+
+pub struct SqliteAppTrackingRepository {
+    connection: Mutex<Connection>,
+}
+
+impl SqliteAppTrackingRepository {
+    pub fn new(path: &Path) -> Result<Self, AppTrackingRepositoryError> {
+        let connection =
+            Connection::open(path).map_err(|error| AppTrackingRepositoryError::Storage {
+                message: error.to_string(),
+            })?;
+
+        let repository = Self {
+            connection: Mutex::new(connection),
+        };
+        repository.initialize_schema()?;
+
+        Ok(repository)
+    }
+
+    pub fn in_memory() -> Result<Self, AppTrackingRepositoryError> {
+        let connection =
+            Connection::open_in_memory().map_err(|error| AppTrackingRepositoryError::Storage {
+                message: error.to_string(),
+            })?;
+
+        let repository = Self {
+            connection: Mutex::new(connection),
+        };
+        repository.initialize_schema()?;
+
+        Ok(repository)
+    }
+
+    fn initialize_schema(&self) -> Result<(), AppTrackingRepositoryError> {
+        let connection = self.connection.lock().unwrap();
+        connection
+            .execute_batch(
+                "CREATE TABLE IF NOT EXISTS app_tracking (
+                    session_id INTEGER NOT NULL,
+                    application_name TEXT NOT NULL,
+                    duration_seconds INTEGER NOT NULL DEFAULT 0,
+                    PRIMARY KEY (session_id, application_name)
+                );",
+            )
+            .map_err(|error| AppTrackingRepositoryError::Storage {
+                message: error.to_string(),
+            })
+    }
+}
+
+impl AppTrackingRepository for SqliteAppTrackingRepository {
+    fn save_or_update(&self, usage: &AppUsage) -> Result<(), AppTrackingRepositoryError> {
+        let connection = self.connection.lock().unwrap();
+
+        connection
+            .execute(
+                "INSERT INTO app_tracking (session_id, application_name, duration_seconds)
+                 VALUES (?1, ?2, ?3)
+                 ON CONFLICT (session_id, application_name)
+                 DO UPDATE SET duration_seconds = duration_seconds + excluded.duration_seconds",
+                params![
+                    usage.session_id,
+                    &usage.application_name,
+                    usage.duration_seconds
+                ],
+            )
+            .map_err(|error| AppTrackingRepositoryError::Storage {
+                message: error.to_string(),
+            })?;
+
+        Ok(())
+    }
+
+    fn find_by_session(
+        &self,
+        session_id: SessionId,
+    ) -> Result<Vec<AppUsage>, AppTrackingRepositoryError> {
+        let connection = self.connection.lock().unwrap();
+
+        let mut statement = connection
+            .prepare(
+                "SELECT session_id, application_name, duration_seconds
+                 FROM app_tracking
+                 WHERE session_id = ?1
+                 ORDER BY duration_seconds DESC",
+            )
+            .map_err(|error| AppTrackingRepositoryError::Storage {
+                message: error.to_string(),
+            })?;
+
+        let usages = statement
+            .query_map(params![session_id], |row| Ok(row_to_app_usage(row)))
+            .map_err(|error| AppTrackingRepositoryError::Storage {
+                message: error.to_string(),
+            })?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|error| AppTrackingRepositoryError::Storage {
+                message: error.to_string(),
+            })?;
+
+        Ok(usages)
+    }
+
+    fn find_by_sessions(
+        &self,
+        session_ids: &[SessionId],
+    ) -> Result<Vec<AppUsage>, AppTrackingRepositoryError> {
+        if session_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let connection = self.connection.lock().unwrap();
+
+        let placeholders: String = session_ids
+            .iter()
+            .map(|_| "?")
+            .collect::<Vec<_>>()
+            .join(",");
+        let query = format!(
+            "SELECT 0 as session_id, application_name, SUM(duration_seconds) as total_seconds
+             FROM app_tracking
+             WHERE session_id IN ({})
+             GROUP BY application_name
+             ORDER BY total_seconds DESC",
+            placeholders
+        );
+
+        let mut statement =
+            connection
+                .prepare(&query)
+                .map_err(|error| AppTrackingRepositoryError::Storage {
+                    message: error.to_string(),
+                })?;
+
+        let usages = statement
+            .query_map(rusqlite::params_from_iter(session_ids.iter()), |row| {
+                Ok(row_to_app_usage(row))
+            })
+            .map_err(|error| AppTrackingRepositoryError::Storage {
+                message: error.to_string(),
+            })?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|error| AppTrackingRepositoryError::Storage {
+                message: error.to_string(),
+            })?;
+
+        Ok(usages)
+    }
+
+    fn delete_by_session(&self, session_id: SessionId) -> Result<(), AppTrackingRepositoryError> {
+        let connection = self.connection.lock().unwrap();
+
+        connection
+            .execute(
+                "DELETE FROM app_tracking WHERE session_id = ?1",
+                params![session_id],
+            )
+            .map_err(|error| AppTrackingRepositoryError::Storage {
+                message: error.to_string(),
+            })?;
+
+        Ok(())
+    }
+}
+
+fn row_to_app_usage(row: &rusqlite::Row) -> AppUsage {
+    let session_id: i64 = row.get(0).unwrap();
+    let application_name: String = row.get(1).unwrap();
+    let duration_seconds: i64 = row.get(2).unwrap();
+
+    AppUsage {
+        session_id,
+        application_name,
+        duration_seconds,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn save_and_retrieve_app_usage() {
+        let repository = SqliteAppTrackingRepository::in_memory().unwrap();
+
+        let usage = AppUsage::with_duration(1, "cursor".to_string(), 60);
+        repository.save_or_update(&usage).unwrap();
+
+        let usages = repository.find_by_session(1).unwrap();
+
+        assert_eq!(usages.len(), 1);
+        assert_eq!(usages[0].application_name, "cursor");
+        assert_eq!(usages[0].duration_seconds, 60);
+    }
+
+    #[test]
+    fn save_or_update_accumulates_duration() {
+        let repository = SqliteAppTrackingRepository::in_memory().unwrap();
+
+        let usage1 = AppUsage::with_duration(1, "cursor".to_string(), 30);
+        repository.save_or_update(&usage1).unwrap();
+
+        let usage2 = AppUsage::with_duration(1, "cursor".to_string(), 25);
+        repository.save_or_update(&usage2).unwrap();
+
+        let usages = repository.find_by_session(1).unwrap();
+
+        assert_eq!(usages.len(), 1);
+        assert_eq!(usages[0].duration_seconds, 55);
+    }
+
+    #[test]
+    fn multiple_apps_in_same_session() {
+        let repository = SqliteAppTrackingRepository::in_memory().unwrap();
+
+        repository
+            .save_or_update(&AppUsage::with_duration(1, "cursor".to_string(), 100))
+            .unwrap();
+        repository
+            .save_or_update(&AppUsage::with_duration(1, "firefox".to_string(), 50))
+            .unwrap();
+        repository
+            .save_or_update(&AppUsage::with_duration(1, "alacritty".to_string(), 30))
+            .unwrap();
+
+        let usages = repository.find_by_session(1).unwrap();
+
+        assert_eq!(usages.len(), 3);
+        assert_eq!(usages[0].application_name, "cursor");
+        assert_eq!(usages[1].application_name, "firefox");
+        assert_eq!(usages[2].application_name, "alacritty");
+    }
+
+    #[test]
+    fn find_by_sessions_aggregates_across_sessions() {
+        let repository = SqliteAppTrackingRepository::in_memory().unwrap();
+
+        repository
+            .save_or_update(&AppUsage::with_duration(1, "cursor".to_string(), 100))
+            .unwrap();
+        repository
+            .save_or_update(&AppUsage::with_duration(2, "cursor".to_string(), 50))
+            .unwrap();
+        repository
+            .save_or_update(&AppUsage::with_duration(1, "firefox".to_string(), 30))
+            .unwrap();
+
+        let usages = repository.find_by_sessions(&[1, 2]).unwrap();
+
+        assert_eq!(usages.len(), 2);
+        assert_eq!(usages[0].application_name, "cursor");
+        assert_eq!(usages[0].duration_seconds, 150);
+        assert_eq!(usages[1].application_name, "firefox");
+        assert_eq!(usages[1].duration_seconds, 30);
+    }
+
+    #[test]
+    fn find_by_sessions_returns_empty_for_empty_input() {
+        let repository = SqliteAppTrackingRepository::in_memory().unwrap();
+
+        let usages = repository.find_by_sessions(&[]).unwrap();
+
+        assert!(usages.is_empty());
+    }
+
+    #[test]
+    fn delete_by_session_removes_all_app_data() {
+        let repository = SqliteAppTrackingRepository::in_memory().unwrap();
+
+        repository
+            .save_or_update(&AppUsage::with_duration(1, "cursor".to_string(), 100))
+            .unwrap();
+        repository
+            .save_or_update(&AppUsage::with_duration(1, "firefox".to_string(), 50))
+            .unwrap();
+        repository
+            .save_or_update(&AppUsage::with_duration(2, "cursor".to_string(), 30))
+            .unwrap();
+
+        repository.delete_by_session(1).unwrap();
+
+        let session1_usages = repository.find_by_session(1).unwrap();
+        let session2_usages = repository.find_by_session(2).unwrap();
+
+        assert!(session1_usages.is_empty());
+        assert_eq!(session2_usages.len(), 1);
+    }
+
+    #[test]
+    fn results_ordered_by_duration_descending() {
+        let repository = SqliteAppTrackingRepository::in_memory().unwrap();
+
+        repository
+            .save_or_update(&AppUsage::with_duration(1, "low".to_string(), 10))
+            .unwrap();
+        repository
+            .save_or_update(&AppUsage::with_duration(1, "high".to_string(), 100))
+            .unwrap();
+        repository
+            .save_or_update(&AppUsage::with_duration(1, "medium".to_string(), 50))
+            .unwrap();
+
+        let usages = repository.find_by_session(1).unwrap();
+
+        assert_eq!(usages[0].application_name, "high");
+        assert_eq!(usages[1].application_name, "medium");
+        assert_eq!(usages[2].application_name, "low");
+    }
+}

--- a/crates/flux-adapters/src/sqlite/mod.rs
+++ b/crates/flux-adapters/src/sqlite/mod.rs
@@ -1,3 +1,5 @@
+mod app_tracking_repository;
 mod session_repository;
 
+pub use app_tracking_repository::SqliteAppTrackingRepository;
 pub use session_repository::SqliteSessionRepository;

--- a/crates/flux-core/src/domain/app_usage.rs
+++ b/crates/flux-core/src/domain/app_usage.rs
@@ -1,0 +1,49 @@
+use super::SessionId;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct AppUsage {
+    pub session_id: SessionId,
+    pub application_name: String,
+    pub duration_seconds: i64,
+}
+
+impl AppUsage {
+    pub fn new(session_id: SessionId, application_name: String) -> Self {
+        Self {
+            session_id,
+            application_name,
+            duration_seconds: 0,
+        }
+    }
+
+    pub fn with_duration(session_id: SessionId, application_name: String, seconds: i64) -> Self {
+        Self {
+            session_id,
+            application_name,
+            duration_seconds: seconds,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_creates_usage_with_zero_duration() {
+        let usage = AppUsage::new(1, "cursor".to_string());
+
+        assert_eq!(usage.session_id, 1);
+        assert_eq!(usage.application_name, "cursor");
+        assert_eq!(usage.duration_seconds, 0);
+    }
+
+    #[test]
+    fn with_duration_creates_usage_with_specified_seconds() {
+        let usage = AppUsage::with_duration(42, "firefox".to_string(), 300);
+
+        assert_eq!(usage.session_id, 42);
+        assert_eq!(usage.application_name, "firefox");
+        assert_eq!(usage.duration_seconds, 300);
+    }
+}

--- a/crates/flux-core/src/domain/mod.rs
+++ b/crates/flux-core/src/domain/mod.rs
@@ -1,7 +1,9 @@
+mod app_usage;
 mod focus_mode;
 mod review_event;
 mod session;
 
+pub use app_usage::AppUsage;
 pub use focus_mode::FocusMode;
 pub use review_event::{Provider, ReviewAction, ReviewEvent};
 pub use session::{Session, SessionId};

--- a/crates/flux-core/src/lib.rs
+++ b/crates/flux-core/src/lib.rs
@@ -13,10 +13,11 @@ pub use config::{
     Config, ConfigError, FocusConfig, GeneralConfig, NotificationConfig, NotificationUrgency,
     TrayConfig,
 };
-pub use domain::{FocusMode, Provider, ReviewAction, ReviewEvent, Session, SessionId};
+pub use domain::{AppUsage, FocusMode, Provider, ReviewAction, ReviewEvent, Session, SessionId};
 pub use i18n::{Language, Translator, UnsupportedLanguageError};
 pub use ports::{
-    ReviewActivityGateway, ReviewGatewayError, SessionRepository, SessionRepositoryError,
+    AppTrackingRepository, AppTrackingRepositoryError, ReviewActivityGateway, ReviewGatewayError,
+    SessionRepository, SessionRepositoryError,
 };
 pub use secrets::{
     resolve_github_credentials, resolve_gitlab_credentials, ProviderCredentials, SecretsError,

--- a/crates/flux-core/src/ports/app_tracking_repository.rs
+++ b/crates/flux-core/src/ports/app_tracking_repository.rs
@@ -1,0 +1,25 @@
+use thiserror::Error;
+
+use crate::domain::{AppUsage, SessionId};
+
+#[derive(Error, Debug)]
+pub enum AppTrackingRepositoryError {
+    #[error("erreur de persistence: {message}")]
+    Storage { message: String },
+}
+
+pub trait AppTrackingRepository: Send + Sync {
+    fn save_or_update(&self, usage: &AppUsage) -> Result<(), AppTrackingRepositoryError>;
+
+    fn find_by_session(
+        &self,
+        session_id: SessionId,
+    ) -> Result<Vec<AppUsage>, AppTrackingRepositoryError>;
+
+    fn find_by_sessions(
+        &self,
+        session_ids: &[SessionId],
+    ) -> Result<Vec<AppUsage>, AppTrackingRepositoryError>;
+
+    fn delete_by_session(&self, session_id: SessionId) -> Result<(), AppTrackingRepositoryError>;
+}

--- a/crates/flux-core/src/ports/mod.rs
+++ b/crates/flux-core/src/ports/mod.rs
@@ -1,5 +1,7 @@
+mod app_tracking_repository;
 mod review_activity_gateway;
 mod session_repository;
 
+pub use app_tracking_repository::{AppTrackingRepository, AppTrackingRepositoryError};
 pub use review_activity_gateway::{ReviewActivityGateway, ReviewGatewayError};
 pub use session_repository::{SessionRepository, SessionRepositoryError};

--- a/crates/flux-daemon/Cargo.toml
+++ b/crates/flux-daemon/Cargo.toml
@@ -25,3 +25,4 @@ libc.workspace = true
 [target.'cfg(target_os = "linux")'.dependencies]
 ksni.workspace = true
 which.workspace = true
+x11rb = { version = "0.13", features = ["allow-unsafe-code"] }

--- a/crates/flux-daemon/src/actors/app_tracker.rs
+++ b/crates/flux-daemon/src/actors/app_tracker.rs
@@ -1,0 +1,305 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::sync::mpsc;
+use tracing::{debug, error, info, trace, warn};
+
+use flux_core::{AppTrackingRepository, AppUsage, SessionId};
+
+#[cfg(target_os = "linux")]
+use crate::window::{WindowDetector, X11WindowDetector};
+
+const POLLING_INTERVAL_SECONDS: u64 = 5;
+
+pub enum AppTrackerMessage {
+    SessionStarted { session_id: SessionId },
+    SessionEnded,
+    SessionPaused,
+    SessionResumed,
+}
+
+#[derive(Clone)]
+pub struct AppTrackerHandle {
+    sender: mpsc::Sender<AppTrackerMessage>,
+}
+
+impl AppTrackerHandle {
+    pub fn send_session_started(&self, session_id: SessionId) {
+        let sender = self.sender.clone();
+        tokio::spawn(async move {
+            if let Err(error) = sender
+                .send(AppTrackerMessage::SessionStarted { session_id })
+                .await
+            {
+                error!(%error, "failed to send session started message to app tracker");
+            }
+        });
+    }
+
+    pub fn send_session_ended(&self) {
+        let sender = self.sender.clone();
+        tokio::spawn(async move {
+            if let Err(error) = sender.send(AppTrackerMessage::SessionEnded).await {
+                error!(%error, "failed to send session ended message to app tracker");
+            }
+        });
+    }
+
+    pub fn send_session_paused(&self) {
+        let sender = self.sender.clone();
+        tokio::spawn(async move {
+            if let Err(error) = sender.send(AppTrackerMessage::SessionPaused).await {
+                error!(%error, "failed to send session paused message to app tracker");
+            }
+        });
+    }
+
+    pub fn send_session_resumed(&self) {
+        let sender = self.sender.clone();
+        tokio::spawn(async move {
+            if let Err(error) = sender.send(AppTrackerMessage::SessionResumed).await {
+                error!(%error, "failed to send session resumed message to app tracker");
+            }
+        });
+    }
+}
+
+struct TrackerState {
+    session_id: SessionId,
+    paused: bool,
+    accumulated: HashMap<String, i64>,
+}
+
+pub struct AppTrackerActor {
+    receiver: mpsc::Receiver<AppTrackerMessage>,
+    repository: Arc<dyn AppTrackingRepository>,
+    #[cfg(target_os = "linux")]
+    detector: Option<X11WindowDetector>,
+    state: Option<TrackerState>,
+}
+
+impl AppTrackerActor {
+    #[cfg(target_os = "linux")]
+    pub fn new(repository: Arc<dyn AppTrackingRepository>) -> (Self, AppTrackerHandle) {
+        let (sender, receiver) = mpsc::channel(32);
+
+        let detector = X11WindowDetector::new();
+        if detector.is_none() {
+            warn!("X11 window detection not available, app tracking will be disabled");
+        }
+
+        let actor = Self {
+            receiver,
+            repository,
+            detector,
+            state: None,
+        };
+
+        let handle = AppTrackerHandle { sender };
+
+        (actor, handle)
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    pub fn new(repository: Arc<dyn AppTrackingRepository>) -> (Self, AppTrackerHandle) {
+        let (sender, receiver) = mpsc::channel(32);
+
+        let actor = Self {
+            receiver,
+            repository,
+            state: None,
+        };
+
+        let handle = AppTrackerHandle { sender };
+
+        (actor, handle)
+    }
+
+    pub async fn run(mut self) {
+        info!("app tracker actor started");
+
+        let mut poll_interval =
+            tokio::time::interval(Duration::from_secs(POLLING_INTERVAL_SECONDS));
+
+        loop {
+            tokio::select! {
+                Some(message) = self.receiver.recv() => {
+                    self.handle_message(message);
+                }
+                _ = poll_interval.tick() => {
+                    self.poll_active_window();
+                }
+                else => break,
+            }
+        }
+
+        debug!("app tracker actor stopped");
+    }
+
+    fn handle_message(&mut self, message: AppTrackerMessage) {
+        match message {
+            AppTrackerMessage::SessionStarted { session_id } => {
+                debug!(session_id, "app tracking started for session");
+                self.state = Some(TrackerState {
+                    session_id,
+                    paused: false,
+                    accumulated: HashMap::new(),
+                });
+            }
+            AppTrackerMessage::SessionEnded => {
+                if let Some(state) = self.state.take() {
+                    Self::flush_to_repository(&self.repository, &state);
+                    debug!(
+                        session_id = state.session_id,
+                        "app tracking ended for session"
+                    );
+                }
+            }
+            AppTrackerMessage::SessionPaused => {
+                if let Some(mut state) = self.state.take() {
+                    state.paused = true;
+                    Self::flush_to_repository(&self.repository, &state);
+                    state.accumulated.clear();
+                    self.state = Some(state);
+                    debug!("app tracking paused");
+                }
+            }
+            AppTrackerMessage::SessionResumed => {
+                if let Some(ref mut state) = self.state {
+                    state.paused = false;
+                    debug!("app tracking resumed");
+                }
+            }
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    fn poll_active_window(&mut self) {
+        let Some(ref mut state) = self.state else {
+            return;
+        };
+
+        if state.paused {
+            return;
+        }
+
+        let Some(ref detector) = self.detector else {
+            return;
+        };
+
+        if let Some(application_name) = detector.get_active_application() {
+            trace!(application_name = %application_name, "tracking active window");
+            *state.accumulated.entry(application_name).or_insert(0) +=
+                POLLING_INTERVAL_SECONDS as i64;
+        }
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    fn poll_active_window(&mut self) {
+        // No-op on non-Linux platforms
+    }
+
+    fn flush_to_repository(repository: &Arc<dyn AppTrackingRepository>, state: &TrackerState) {
+        for (application_name, seconds) in &state.accumulated {
+            if *seconds > 0 {
+                let usage =
+                    AppUsage::with_duration(state.session_id, application_name.clone(), *seconds);
+
+                if let Err(error) = repository.save_or_update(&usage) {
+                    error!(%error, application_name, "failed to persist app usage");
+                } else {
+                    debug!(
+                        session_id = state.session_id,
+                        application_name, seconds, "flushed app usage to database"
+                    );
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use flux_core::AppTrackingRepositoryError;
+    use std::sync::Mutex;
+
+    struct MockRepository {
+        saved: Mutex<Vec<AppUsage>>,
+    }
+
+    impl MockRepository {
+        fn new() -> Self {
+            Self {
+                saved: Mutex::new(Vec::new()),
+            }
+        }
+    }
+
+    impl AppTrackingRepository for MockRepository {
+        fn save_or_update(&self, usage: &AppUsage) -> Result<(), AppTrackingRepositoryError> {
+            self.saved.lock().unwrap().push(usage.clone());
+            Ok(())
+        }
+
+        fn find_by_session(
+            &self,
+            _session_id: SessionId,
+        ) -> Result<Vec<AppUsage>, AppTrackingRepositoryError> {
+            Ok(Vec::new())
+        }
+
+        fn find_by_sessions(
+            &self,
+            _session_ids: &[SessionId],
+        ) -> Result<Vec<AppUsage>, AppTrackingRepositoryError> {
+            Ok(Vec::new())
+        }
+
+        fn delete_by_session(
+            &self,
+            _session_id: SessionId,
+        ) -> Result<(), AppTrackingRepositoryError> {
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn handle_can_send_messages() {
+        let repository = Arc::new(MockRepository::new());
+        let (actor, handle) = AppTrackerActor::new(repository);
+
+        let actor_task = tokio::spawn(async move {
+            tokio::time::timeout(Duration::from_millis(100), actor.run()).await
+        });
+
+        handle.send_session_started(1);
+        handle.send_session_paused();
+        handle.send_session_resumed();
+        handle.send_session_ended();
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        drop(handle);
+
+        let _ = actor_task.await;
+    }
+
+    #[tokio::test]
+    async fn session_end_flushes_accumulated_data() {
+        let repository = Arc::new(MockRepository::new());
+        let repository_clone = repository.clone();
+        let (mut actor, _handle) = AppTrackerActor::new(repository);
+
+        actor.state = Some(TrackerState {
+            session_id: 42,
+            paused: false,
+            accumulated: HashMap::from([("cursor".to_string(), 100), ("firefox".to_string(), 50)]),
+        });
+
+        actor.handle_message(AppTrackerMessage::SessionEnded);
+
+        let saved = repository_clone.saved.lock().unwrap();
+        assert_eq!(saved.len(), 2);
+    }
+}

--- a/crates/flux-daemon/src/actors/mod.rs
+++ b/crates/flux-daemon/src/actors/mod.rs
@@ -1,8 +1,10 @@
+mod app_tracker;
 mod notifier;
 mod timer;
 #[cfg(target_os = "linux")]
 mod tray;
 
+pub use app_tracker::{AppTrackerActor, AppTrackerHandle};
 pub use notifier::{NotifierActor, NotifierHandle};
 pub use timer::{TimerActor, TimerHandle};
 #[cfg(target_os = "linux")]

--- a/crates/flux-daemon/src/window/mod.rs
+++ b/crates/flux-daemon/src/window/mod.rs
@@ -1,0 +1,9 @@
+#[cfg(target_os = "linux")]
+mod x11_detector;
+
+#[cfg(target_os = "linux")]
+pub use x11_detector::X11WindowDetector;
+
+pub trait WindowDetector: Send + Sync {
+    fn get_active_application(&self) -> Option<String>;
+}

--- a/crates/flux-daemon/src/window/x11_detector.rs
+++ b/crates/flux-daemon/src/window/x11_detector.rs
@@ -1,0 +1,222 @@
+use std::fs;
+use std::path::Path;
+
+use tracing::{debug, trace, warn};
+use x11rb::connection::Connection;
+use x11rb::protocol::xproto::{AtomEnum, ConnectionExt, Window};
+use x11rb::rust_connection::RustConnection;
+
+use super::WindowDetector;
+
+pub struct X11WindowDetector {
+    connection: RustConnection,
+    root_window: Window,
+    active_window_atom: u32,
+    wm_class_atom: u32,
+    wm_pid_atom: u32,
+}
+
+impl X11WindowDetector {
+    pub fn new() -> Option<Self> {
+        let (connection, screen_number) = RustConnection::connect(None)
+            .map_err(|error| {
+                warn!(%error, "failed to connect to X11 display");
+            })
+            .ok()?;
+
+        let screen = &connection.setup().roots[screen_number];
+        let root_window = screen.root;
+
+        let active_window_atom = connection
+            .intern_atom(false, b"_NET_ACTIVE_WINDOW")
+            .ok()?
+            .reply()
+            .ok()?
+            .atom;
+
+        let wm_class_atom = AtomEnum::WM_CLASS.into();
+
+        let wm_pid_atom = connection
+            .intern_atom(false, b"_NET_WM_PID")
+            .ok()?
+            .reply()
+            .ok()?
+            .atom;
+
+        debug!("X11 window detector initialized");
+
+        Some(Self {
+            connection,
+            root_window,
+            active_window_atom,
+            wm_class_atom,
+            wm_pid_atom,
+        })
+    }
+
+    fn get_active_window(&self) -> Option<Window> {
+        let reply = self
+            .connection
+            .get_property(
+                false,
+                self.root_window,
+                self.active_window_atom,
+                AtomEnum::WINDOW,
+                0,
+                1,
+            )
+            .ok()?
+            .reply()
+            .ok()?;
+
+        if reply.value.len() >= 4 {
+            let window_id = u32::from_ne_bytes([
+                reply.value[0],
+                reply.value[1],
+                reply.value[2],
+                reply.value[3],
+            ]);
+            if window_id != 0 {
+                return Some(window_id);
+            }
+        }
+
+        None
+    }
+
+    fn get_window_class(&self, window: Window) -> Option<String> {
+        let reply = self
+            .connection
+            .get_property(false, window, self.wm_class_atom, AtomEnum::STRING, 0, 2048)
+            .ok()?
+            .reply()
+            .ok()?;
+
+        if reply.value.is_empty() {
+            return None;
+        }
+
+        let parts: Vec<&str> = std::str::from_utf8(&reply.value)
+            .ok()?
+            .split('\0')
+            .filter(|s| !s.is_empty())
+            .collect();
+
+        parts.get(1).or(parts.first()).map(|s| s.to_string())
+    }
+
+    fn get_window_pid(&self, window: Window) -> Option<u32> {
+        let reply = self
+            .connection
+            .get_property(false, window, self.wm_pid_atom, AtomEnum::CARDINAL, 0, 1)
+            .ok()?
+            .reply()
+            .ok()?;
+
+        if reply.value.len() >= 4 {
+            let pid = u32::from_ne_bytes([
+                reply.value[0],
+                reply.value[1],
+                reply.value[2],
+                reply.value[3],
+            ]);
+            return Some(pid);
+        }
+
+        None
+    }
+
+    fn is_claude_code_running(&self, window_pid: u32) -> bool {
+        self.find_claude_in_process_tree(window_pid)
+    }
+
+    fn find_claude_in_process_tree(&self, parent_pid: u32) -> bool {
+        let proc_path = Path::new("/proc");
+
+        if let Ok(entries) = fs::read_dir(proc_path) {
+            for entry in entries.flatten() {
+                let file_name = entry.file_name();
+                let name = file_name.to_string_lossy();
+
+                if let Ok(pid) = name.parse::<u32>() {
+                    if self.is_child_of(pid, parent_pid) && self.is_claude_process(pid) {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        false
+    }
+
+    fn is_child_of(&self, pid: u32, parent_pid: u32) -> bool {
+        let status_path = format!("/proc/{}/status", pid);
+
+        if let Ok(content) = fs::read_to_string(&status_path) {
+            for line in content.lines() {
+                if let Some(ppid_str) = line.strip_prefix("PPid:\t") {
+                    if let Ok(ppid) = ppid_str.trim().parse::<u32>() {
+                        if ppid == parent_pid {
+                            return true;
+                        }
+                        if ppid != 0 && ppid != 1 {
+                            return self.is_child_of(ppid, parent_pid);
+                        }
+                    }
+                }
+            }
+        }
+
+        false
+    }
+
+    fn is_claude_process(&self, pid: u32) -> bool {
+        let cmdline_path = format!("/proc/{}/cmdline", pid);
+
+        if let Ok(content) = fs::read_to_string(&cmdline_path) {
+            let lowercase = content.to_lowercase();
+            if lowercase.contains("claude") && !lowercase.contains("claudecode") {
+                trace!(pid, "found claude process");
+                return true;
+            }
+        }
+
+        false
+    }
+}
+
+impl WindowDetector for X11WindowDetector {
+    fn get_active_application(&self) -> Option<String> {
+        let window = self.get_active_window()?;
+        let window_class = self.get_window_class(window)?;
+
+        let lowercase_class = window_class.to_lowercase();
+
+        if lowercase_class.contains("cursor") || lowercase_class.contains("code") {
+            if let Some(pid) = self.get_window_pid(window) {
+                if self.is_claude_code_running(pid) {
+                    debug!(window_class = %window_class, "detected Claude Code in editor");
+                    return Some("Claude Code".to_string());
+                }
+            }
+        }
+
+        debug!(window_class = %window_class, "detected active application");
+        Some(window_class)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detector_can_be_created_or_fails_gracefully() {
+        let detector = X11WindowDetector::new();
+
+        match detector {
+            Some(_) => println!("X11 detector created successfully"),
+            None => println!("X11 not available (expected in CI)"),
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Track active window during focus sessions using X11 (via x11rb native library)
- Detect focused application every 5 seconds and aggregate time per app
- Special detection for Claude Code when running inside Cursor terminal
- Display app breakdown in CLI `flux stats` and GUI dashboard

## Changes
- **flux-core**: Add `AppUsage` entity and `AppTrackingRepository` trait
- **flux-adapters**: Implement `SqliteAppTrackingRepository` with INSERT ON CONFLICT UPDATE
- **flux-daemon**: Create `X11WindowDetector` using x11rb (no system dependencies)
- **flux-daemon**: Add `AppTrackerActor` with fire-and-forget messaging pattern
- **flux-daemon**: Integrate with `TimerActor` for session lifecycle events
- **flux-cli/gui**: Display app breakdown in stats

## Test plan
- [ ] Start daemon: `cargo run -p flux-daemon`
- [ ] Start session: `cargo run -p flux-cli -- start`
- [ ] Switch applications for 30+ seconds
- [ ] Stop session: `cargo run -p flux-cli -- stop`
- [ ] Verify stats: `cargo run -p flux-cli -- stats`
- [ ] Verify DB: `sqlite3 ~/.local/share/flux/sessions.db "SELECT * FROM app_tracking;"`
- [ ] Check GUI dashboard shows app breakdown