### PR TITLE
feat(daemon): add distraction detection and alerts

### DIFF
--- a/crates/flux-core/src/i18n/locales/en.toml
+++ b/crates/flux-core/src/i18n/locales/en.toml
@@ -87,7 +87,9 @@ paused = "Session paused"
 
 [notification]
 check_in_title = "Focus Check-in"
-check_in_body = "{minutes}min elapsed. Still focused?"
+check_in_body = "{percent}% completed. Still focused?"
+check_in_yes = "Yes"
+check_in_no = "No"
 session_start_title = "Session Started"
 session_start_body = "{duration}min focus session started. Stay focused!"
 session_end_title = "Session Complete"
@@ -96,6 +98,8 @@ paused_title = "Paused"
 paused_body = "Session paused"
 resumed_title = "Resumed"
 resumed_body = "Session resumed. Stay focused!"
+distraction_alert_title = "Distraction Alert"
+distraction_alert_body = "You've been on {app} for {seconds}s"
 
 [gui]
 tab_overview = "Overview"

--- a/crates/flux-core/src/i18n/locales/fr.toml
+++ b/crates/flux-core/src/i18n/locales/fr.toml
@@ -87,7 +87,9 @@ paused = "Session en pause"
 
 [notification]
 check_in_title = "Check-in Focus"
-check_in_body = "{minutes}min écoulées. Toujours concentré ?"
+check_in_body = "{percent}% complété. Toujours concentré ?"
+check_in_yes = "Oui"
+check_in_no = "Non"
 session_start_title = "Session démarrée"
 session_start_body = "Session focus de {duration}min démarrée. Bonne concentration !"
 session_end_title = "Session terminée"
@@ -96,6 +98,8 @@ paused_title = "Pause"
 paused_body = "Session mise en pause"
 resumed_title = "Reprise"
 resumed_body = "Session reprise. Bonne concentration !"
+distraction_alert_title = "Alerte Distraction"
+distraction_alert_body = "Tu es sur {app} depuis {seconds}s"
 
 [gui]
 tab_overview = "Vue d'ensemble"

--- a/crates/flux-core/src/lib.rs
+++ b/crates/flux-core/src/lib.rs
@@ -10,8 +10,8 @@ pub mod ports;
 pub mod secrets;
 
 pub use config::{
-    Config, ConfigError, FocusConfig, GeneralConfig, NotificationConfig, NotificationUrgency,
-    TrayConfig,
+    Config, ConfigError, DistractionConfig, FocusConfig, GeneralConfig, NotificationConfig,
+    NotificationUrgency, TrayConfig,
 };
 pub use domain::{AppUsage, FocusMode, Provider, ReviewAction, ReviewEvent, Session, SessionId};
 pub use i18n::{Language, Translator, UnsupportedLanguageError};

--- a/crates/flux-daemon/src/main.rs
+++ b/crates/flux-daemon/src/main.rs
@@ -66,7 +66,11 @@ async fn main() -> Result<()> {
     let app_tracking_repository = create_app_tracking_repository();
 
     let app_tracker_handle = if let Some(repository) = app_tracking_repository {
-        let (app_tracker_actor, handle) = AppTrackerActor::new(repository);
+        let (app_tracker_actor, handle) = AppTrackerActor::new(
+            repository,
+            config.distractions.clone(),
+            notifier_handle.clone(),
+        );
         tokio::spawn(app_tracker_actor.run());
         Some(handle)
     } else {


### PR DESCRIPTION
## Summary

- Add `DistractionConfig` with configurable app list and alert threshold settings
- Track consecutive time spent on distraction apps during focus sessions
- Send notification alert when user stays on a distraction app beyond threshold

## Configuration

```toml
[distractions]
apps = ["discord", "slack", "telegram", "whatsapp", "twitter", "youtube", "reddit"]
alert_enabled = true
alert_after_seconds = 30
```

## Test plan

- [x] CI passes (build, test, clippy, fmt)
- [ ] Start a focus session with `alert_enabled = true`
- [ ] Switch to Discord for 30+ seconds
- [ ] Verify notification alert is received
- [ ] Switch back to IDE, verify counter resets